### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NickScarpitti/common-net-funcs/security/code-scanning/3](https://github.com/NickScarpitti/common-net-funcs/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow. Based on the provided workflow, it primarily performs actions like checking out the repository, installing dependencies, and running tests. These tasks typically require `contents: read` permission. If the workflow does not need to write to the repository (e.g., creating pull requests or issues), no additional permissions are necessary.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
